### PR TITLE
fixed typo, section with no content

### DIFF
--- a/docs/contributing.html
+++ b/docs/contributing.html
@@ -70,9 +70,9 @@
   					<div class="card-body">
   						<h1 class="card-title" id="contributing-intro">Contributing to the ICT Baseline Alignment Framework</h1>
                             <h2 id="helping">How you can help:</h2>
-                                <h3 id="test-cases">Developing and Evaluating Test Cases</h3>
+                               <!-- <h3 id="test-cases">Developing and Evaluating Test Cases</h3>
                                     <p class="card-text">Need content from people doing this work. What do you need?</p>
-                                    <p class="card-text">I have a note about issuing templates. Does that belong bundled with this topic?</p>
+                                    <p class="card-text">I have a note about issuing templates. Does that belong bundled with this topic?</p> -->
                                 <h3 id="outreach">Planning and Conducting Outreach</h3>
                                     <p class="card-text">We need people to know about our work so they can contribute and use it! Whether you enjoy giving presentations or would prefer to remain behind the scenes writing and editing, your skills are needed. Can you help with any of the following?</p>
                                     <ul>
@@ -83,7 +83,7 @@
                                 <h3 id="governance">Developing and Conducting Governance</h3>
                                     <p class="card-text">Any project this size needs a program manager. Are you game? Or do you have process management or change control expertise that you could use to help ensure the test cases remain in alignment with the baseline?</p>
                                     <p class="card-text">Once the test cases are ready, we'll need to have a way of validating alignment to the ICT Baseline. We're still working out how that would work (and could use your input), but we know we'll need people to manage alignment certification. Also, disputes will occasionally arise, and we'll need people with the technical and soft skills necessary to resolve them.</p>
-                                <h3 id="website">Developing and Maintaing this Website</h3>
+                                <h3 id="website">Developing and Maintaining this Website</h3>
                                     <p class="card-text">We want this website to serve the needs of contributors and testers alike. We also need the basic information to be intelligible to Section 508 program managers, procurement officials, and others with potentially less technical knowledge so they can understand what this project is all about and how their agencies can benefit from it. And, of course, the website must be usable and accessible. Therefore, we could use your help with:</p>
                                     <ul>
                                         <li>Designing and testing</li>


### PR DESCRIPTION
Remmed out first section (Developing and Evaluating Test Cases) because it has no content.

Fixed "maintaining" in heading.