### PR TITLE
Potential fix for code scanning alert no. 81: DOM text reinterpreted as HTML

### DIFF
--- a/testfiles/TF10/TC10.7-2.b-pass-1.html
+++ b/testfiles/TF10/TC10.7-2.b-pass-1.html
@@ -74,7 +74,7 @@
                 //hide order form
                 document.getElementById("order-form").setAttribute("hidden","hidden");
 
-                document.getElementById("pizza-number").innerHTML = number;
+                document.getElementById("pizza-number").textContent = number;
                 document.getElementById("pizza-time").innerHTML = time;
 
                 const pizza_price = 10; //dollars


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/baselinealignment/security/code-scanning/81](https://github.com/GSA/baselinealignment/security/code-scanning/81)

To fix this issue, we should avoid using `innerHTML` to insert user-controlled data into the DOM. Instead, we can use `textContent` or `innerText`, which will treat the input as plain text and not as HTML. This change ensures that any potentially malicious input is not executed as code.

- Replace the use of `innerHTML` with `textContent` for the `number` variable.
- Ensure that the `number` value is treated as plain text, preventing any HTML or script injection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
